### PR TITLE
Add method and property flags to code generator

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -147,8 +147,14 @@ methods:
 ## Properties
 
 A property must have the YAML property `name` and `type` and may optionally
-have `description` and `default`.  The `default` defines the default value of
-the property.
+have `description`, `default`, and `flags`.
+
+The `default` defines the default value of the property.
+
+The `flags` are a list of sd-bus flags featuring `deprecated`, `hidden`,
+`unprivileged`, `const`, `emits_change`, `emits_invalidation`, `explicit`
+and a `readonly`. The flag `readonly` prohibits the client from changing
+the property. If `const` is set, `readonly` is implied.
 
 Example:
 ```
@@ -156,6 +162,8 @@ properties:
     - name: CardsRemaining
       type: uint32
       default: 52
+      flags:
+        - const
       description: >
         The number of cards remaining in the deck.
 ```

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -110,17 +110,20 @@ for locally defined types.
 
 ## Methods
 
-A method must have the YAML property `name` and may optionally have
-`parameters`, `returns`, `errors`, and `description`.  Each parameter must
-have a `name`, `type`, and optional `description`.  Each return must have a
-`type` and may optionally have a `name` and `description`.  Errors are a list
-of fully-qualified or shortened `self.` identifiers for errors the method may
-return, which must be defined in a corresponding errors YAML file.
+A method must have the YAML property `name` and may optionally have `flags`,
+`parameters`, `returns`, `errors`, and `description`.  Flags are a list of
+sd-bus flags featuring `deprecated`, 'hidden', `unprivileged` and `no_reply`.
+Each parameter must have a `name`, `type`, and optional `description`.  Each
+return must have a `type` and may optionally have a `name` and `description`.
+Errors are a list of fully-qualified or shortened `self.` identifiers for errors
+the method may return, which must be defined in a corresponding errors YAML file.
 
 Example:
 ```
 methods:
     - name: Shuffle
+      flags:
+        - unprivileged
       errors:
         - self.Error.TooTired
     - name: Deal
@@ -133,6 +136,9 @@ methods:
         - name: Card
           type: struct[enum[self.Suit], byte]
     - name: MoveToTop
+      flags:
+        - unprivileged
+        - no_reply
       parameters:
         - name: Card
           type: struct[enum[self.Suit], byte]

--- a/sdbusplus/vtable.hpp
+++ b/sdbusplus/vtable.hpp
@@ -98,6 +98,13 @@ constexpr vtable_t property_o(const char* member, const char* signature,
                               sd_bus_property_set_t set, size_t offset,
                               decltype(vtable_t::flags) flags = 0);
 
+namespace common_
+{
+    constexpr auto deprecated = SD_BUS_VTABLE_DEPRECATED;
+    constexpr auto hidden = SD_BUS_VTABLE_HIDDEN;
+    constexpr auto unprivileged = SD_BUS_VTABLE_UNPRIVILEGED;
+} // namespace common_
+
 namespace method_
 {
 constexpr auto no_reply = SD_BUS_VTABLE_METHOD_NO_REPLY;

--- a/tools/sdbusplus/method.py
+++ b/tools/sdbusplus/method.py
@@ -5,6 +5,8 @@ from .renderer import Renderer
 
 class Method(NamedElement, Renderer):
     def __init__(self, **kwargs):
+        self.flags = kwargs.pop('flags', [])
+        self.cppFlags = self.cpp_flags(self.flags)
         self.parameters = \
             [Property(**p) for p in kwargs.pop('parameters', [])]
         self.returns = \
@@ -19,3 +21,21 @@ class Method(NamedElement, Renderer):
     def cpp_prototype(self, loader, interface, ptype):
         return self.render(loader, "method.mako.prototype.hpp", method=self,
                            interface=interface, ptype=ptype, post=str.rstrip)
+
+    def cpp_flags(self, flags):
+        flags_map = {
+            "deprecated":"vtable::common_::deprecated",
+            "hidden":"vtable::common_::hidden",
+            "unprivileged":"vtable::common_::unprivileged",
+            "no_reply":"vtable::method_::no_reply"
+        }
+
+        l = []
+        for flag in flags:
+            r = flags_map.get(flag)
+            if r is None:
+                raise RuntimeError("Invalid method flag %s" % flag)
+
+            l.append(r)
+
+        return ' | '.join(l)

--- a/tools/sdbusplus/property.py
+++ b/tools/sdbusplus/property.py
@@ -5,11 +5,37 @@ import yaml
 
 class Property(NamedElement, Renderer):
     def __init__(self, **kwargs):
+        self.flags = kwargs.pop('flags', [])
+        self.cppFlags = self.cpp_flags(self.flags)
         self.typeName = kwargs.pop('type', None)
         self.cppTypeName = self.parse_cpp_type(self.typeName)
         self.defaultValue = kwargs.pop('default', None)
 
         super(Property, self).__init__(**kwargs)
+
+    def cpp_flags(self, flags):
+        flags_map = {
+            "deprecated":"vtable::common_::deprecated",
+            "hidden":"vtable::common_::hidden",
+            "unprivileged":"vtable::common_::unprivileged",
+            "const":"vtable::property_::const_",
+            "emits_change":"vtable::property_::emits_change",
+            "emits_invalidation":"vtable::property_::emits_invalidation",
+            "explicit":"vtable::property_::explicit_"
+        }
+
+        l = []
+        for flag in flags:
+            if flag == 'readonly':
+                continue
+
+            r = flags_map.get(flag)
+            if r is None:
+                raise RuntimeError("Invalid property flag %s" % flag)
+
+            l.append(r)
+
+        return ' | '.join(l)
 
     def is_enum(self):
         if not self.cppTypeName:

--- a/tools/sdbusplus/templates/interface.mako.server.cpp.in
+++ b/tools/sdbusplus/templates/interface.mako.server.cpp.in
@@ -85,6 +85,7 @@ int ${classname}::_callback_get_${p.name}(
     return true;
 }
 
+% if 'const' not in p.flags:
 auto ${classname}::${p.camelCase}(${p.cppTypeParam(interface.name)} value) ->
         ${p.cppTypeParam(interface.name)}
 {
@@ -96,7 +97,9 @@ auto ${classname}::${p.camelCase}(${p.cppTypeParam(interface.name)} value) ->
 
     return _${p.camelCase};
 }
+% endif
 
+% if set(['readonly', 'const']).isdisjoint(p.flags):
 int ${classname}::_callback_set_${p.name}(
         sd_bus* bus, const char* path, const char* interface,
         const char* property, sd_bus_message* value, void* context,
@@ -133,6 +136,7 @@ convert${p.enum_name(interface.name)}FromString(v));
 
     return true;
 }
+% endif
 
 namespace details
 {
@@ -150,6 +154,7 @@ void ${classname}::setPropertyByName(const std::string& name,
                                      const PropertiesVariant& val)
 {
         % for p in interface.properties:
+            % if 'const' not in p.flags:
     if (name == "${p.name}")
     {
         auto& v = message::variant_ns::get<${p.cppTypeParam(interface.name)}>(\
@@ -157,6 +162,7 @@ val);
         ${p.camelCase}(v);
         return;
     }
+            % endif
         % endfor
 }
 
@@ -230,8 +236,14 @@ ${ s.cpp_prototype(loader, interface=interface, ptype='vtable') }
                      details::${classname}::_property_${p.name}
                         .data(),
                      _callback_get_${p.name},
+        % if set(['readonly', 'const']).isdisjoint(p.flags):
                      _callback_set_${p.name},
+        % endif
+        % if not p.cppFlags:
                      vtable::property_::emits_change),
+        % else:
+                     ${p.cppFlags}),
+        % endif
     % endfor
     vtable::end()
 };

--- a/tools/sdbusplus/templates/interface.mako.server.hpp
+++ b/tools/sdbusplus/templates/interface.mako.server.hpp
@@ -79,9 +79,11 @@ ${ s.cpp_prototype(loader, interface=interface, ptype='header') }
     % for p in interface.properties:
         /** Get value of ${p.name} */
         virtual ${p.cppTypeParam(interface.name)} ${p.camelCase}() const;
+        % if 'const' not in p.flags:
         /** Set value of ${p.name} */
         virtual ${p.cppTypeParam(interface.name)} \
 ${p.camelCase}(${p.cppTypeParam(interface.name)} value);
+        % endif
     % endfor
 
     % if interface.properties:
@@ -118,11 +120,12 @@ ${ m.cpp_prototype(loader, interface=interface, ptype='callback-header') }
         static int _callback_get_${p.name}(
             sd_bus*, const char*, const char*, const char*,
             sd_bus_message*, void*, sd_bus_error*);
+        % if set(['readonly', 'const']).isdisjoint(p.flags):
         /** @brief sd-bus callback for set-property '${p.name}' */
         static int _callback_set_${p.name}(
             sd_bus*, const char*, const char*, const char*,
             sd_bus_message*, void*, sd_bus_error*);
-
+        % endif
     % endfor
 
         static constexpr auto _interface = "${interface.name}";

--- a/tools/sdbusplus/templates/method.mako.prototype.hpp.in
+++ b/tools/sdbusplus/templates/method.mako.prototype.hpp.in
@@ -113,7 +113,12 @@
                         .data(),
                    details::${interface_name()}::_return_${ method.CamelCase }
                         .data(),
-                   _callback_${ method.CamelCase }),
+                   _callback_${ method.CamelCase }\
+        % if method.cppFlags:
+,
+                   ${method.cppFlags}\
+        % endif
+),
 ###
 ### Emit 'callback-cpp'
 ###


### PR DESCRIPTION
sd-bus allows to specify flags for methods and properties in the vtable. The sdbusplus code generator currently does not support specifying these flags.

We propose the following two patches to:
- add support for sd-bus method flags unprivileged, deprecated, hidden, and no_reply
- add support for the sd-bus property flags deprecated, hidden, unprivileged, const, emits_change, emits_invalidation, explicit, and readonly