### PR TITLE
sdbusplus::bus::bus Add get_events, get_timeout

### DIFF
--- a/sdbusplus/bus.hpp.in
+++ b/sdbusplus/bus.hpp.in
@@ -391,6 +391,26 @@ struct bus
         return _intf->sd_bus_get_event(_bus.get());
     }
 
+    /** @brief Get the I/O event mask.
+     *
+     * @return the I/O event mask, or negative on failure.
+     */
+    auto get_events()
+    {
+        return _intf->sd_bus_get_events(_bus.get());
+    }
+
+    /** @brief Get the timeout in us to pass to poll().
+     *
+     * @param[out] timeout_usec - the timeout in microseconds.
+     *
+     * @return Zero or positive on success, or negative on failure.
+     */
+    auto get_timeout(uint64_t *timeout_usec)
+    {
+        return _intf->sd_bus_get_timeout(_bus.get(), timeout_usec);
+    }
+
     /** @brief Wrapper for sd_bus_emit_interfaces_added_strv
      *
      *  In general the similarly named server::object::object API should

--- a/sdbusplus/sdbus.hpp
+++ b/sdbusplus/sdbus.hpp
@@ -58,7 +58,9 @@ class SdBusInterface
     virtual void sd_bus_error_free(sd_bus_error* e) = 0;
 
     virtual sd_event* sd_bus_get_event(sd_bus* bus) = 0;
+    virtual int sd_bus_get_events(sd_bus* bus) = 0;
     virtual int sd_bus_get_fd(sd_bus* bus) = 0;
+    virtual int sd_bus_get_timeout(sd_bus* bus, uint64_t* timeout_usec) = 0;
     virtual int sd_bus_get_unique_name(sd_bus* bus, const char** unique) = 0;
 
     virtual int sd_bus_list_names(sd_bus* bus, char*** acquired,
@@ -260,9 +262,19 @@ class SdBusImpl : public SdBusInterface
         return ::sd_bus_get_event(bus);
     }
 
+    int sd_bus_get_events(sd_bus* bus) override
+    {
+        return ::sd_bus_get_events(bus);
+    }
+
     int sd_bus_get_fd(sd_bus* bus) override
     {
         return ::sd_bus_get_fd(bus);
+    }
+
+    int sd_bus_get_timeout(sd_bus* bus, uint64_t* timeout_usec) override
+    {
+        return ::sd_bus_get_timeout(bus, timeout_usec);
     }
 
     int sd_bus_get_unique_name(sd_bus* bus, const char** unique) override


### PR DESCRIPTION
These functions are used in conjunction with the current bus::get_fd()
for implementing an event loop vs bus.wait() which will only wait for
dbus messages and signals.

A manual event loop is useful for allowing communication through a
pipe from a non-dbus worker thread.  Using poll()-like functions in
the main server thread allows waiting for new dbus messages/signals
plus changes in other file descriptors such as a pipe.

See the sd_bus_get_fd manual page.

Signed-off-by: John Faith <jfaith7@gmail.com>