### PR TITLE
[RFC] Allow propagating exceptions from server method implementations

### DIFF
--- a/example/calculator-server.cpp
+++ b/example/calculator-server.cpp
@@ -3,6 +3,7 @@
 #include <net/poettering/Calculator/server.hpp>
 #include <sdbusplus/server.hpp>
 
+#include <cstdlib>
 #include <iostream>
 #include <string_view>
 
@@ -42,10 +43,7 @@ struct Calculator : Calculator_inherit
     /** Clear lastResult, broadcast 'Cleared' signal */
     void clear() override
     {
-        auto v = lastResult();
-        lastResult(0);
-        cleared(v);
-        return;
+        throw std::runtime_error{"A propagating exception"};
     }
 };
 
@@ -71,5 +69,13 @@ int main()
     Calculator c1{b, path};
 
     // Handle dbus processing forever.
-    b.process_loop();
+    try
+    {
+        b.process_loop();
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Terminating due to a fatal condition: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
 }

--- a/include/sdbusplus/bus.hpp
+++ b/include/sdbusplus/bus.hpp
@@ -194,6 +194,10 @@ struct bus
     {
         sd_bus_message* m = nullptr;
         int r = _intf->sd_bus_process(_bus.get(), &m);
+        if (_intf->get_current_exception())
+        {
+            std::rethrow_exception(_intf->get_current_exception());
+        }
         if (r < 0)
         {
             throw exception::SdBusError(-r, "sd_bus_process");
@@ -207,6 +211,10 @@ struct bus
     auto process_discard()
     {
         int r = _intf->sd_bus_process(_bus.get(), nullptr);
+        if (_intf->get_current_exception())
+        {
+            std::rethrow_exception(_intf->get_current_exception());
+        }
         if (r < 0)
         {
             throw exception::SdBusError(-r, "sd_bus_process discard");

--- a/include/sdbusplus/sdbus.hpp
+++ b/include/sdbusplus/sdbus.hpp
@@ -3,6 +3,7 @@
 #include <systemd/sd-bus.h>
 
 #include <chrono>
+#include <exception>
 
 // ABC for sdbus implementation.
 namespace sdbusplus
@@ -171,6 +172,10 @@ class SdBusInterface
     virtual int sd_bus_is_open(sd_bus* bus) = 0;
 
     virtual int sd_bus_wait(sd_bus* bus, uint64_t timeout_usec) = 0;
+
+    virtual void set_current_exception(std::exception_ptr current) = 0;
+
+    virtual std::exception_ptr get_current_exception() const = 0;
 };
 
 class SdBusImpl : public SdBusInterface
@@ -553,6 +558,19 @@ class SdBusImpl : public SdBusInterface
     {
         return ::sd_bus_wait(bus, timeout_usec);
     }
+
+    void set_current_exception(std::exception_ptr exception) override
+    {
+        current_exception = exception;
+    }
+
+    std::exception_ptr get_current_exception() const override
+    {
+        return current_exception;
+    }
+
+  private:
+    std::exception_ptr current_exception;
 };
 
 extern SdBusImpl sdbus_impl;

--- a/tools/sdbusplus/templates/interface.server.cpp.mako
+++ b/tools/sdbusplus/templates/interface.server.cpp.mako
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <exception>
 #include <map>
 #include <sdbusplus/exception.hpp>
 #include <sdbusplus/sdbus.hpp>

--- a/tools/sdbusplus/templates/method.prototype.hpp.mako
+++ b/tools/sdbusplus/templates/method.prototype.hpp.mako
@@ -68,9 +68,7 @@ int ${interface.classname}::_callback_${ method.CamelCase }(
 {
     auto o = static_cast<${interface.classname}*>(context);
 
-    % if method.errors:
     try
-    % endif
     {
         return sdbusplus::sdbuspp::method_callback\
     % if len(method.returns) > 1:
@@ -92,6 +90,11 @@ int ${interface.classname}::_callback_${ method.CamelCase }(
         return o->_intf->sd_bus_error_set(error, e.name(), e.description());
     }
     % endfor
+    catch (const std::exception&)
+    {
+        o->_intf->set_current_exception(std::current_exception());
+        return 1;
+    }
 }
 
 namespace details


### PR DESCRIPTION
## The problem

sdbusplus calls the D-Bus method implementation functions in such a way that the callstack contains `sd_bus` C functions from libsystemd, and sdbusplus only catches the specific exceptions that match the errors defined for the D-Bus method before returning execution to the C functions. If any D-Bus method implementation propagates any other exception than the errors the method declares, the C functions in the callstack may leak resources.

We didn't find any documentation or other statement that would prohibit exceptions from being thrown / propagated from method implementations. This seems to be a known issue though [1]:

    By throwing an exception, you're not making an error return to the calling client, but instead blowing through all of the `sd_bus` C code with your C++ exception and putting your application into an invalid state. At a minimum you are leaking memory.

## The proposed solution

We propose changing sdbusplus to catch any exceptions propagated from method implementations and to re-throw them from `sdbusplus::bus::bus::process*()`.

First of all catching and re-throwing would avoid resource leaks from `sd_bus` C functions. And as a consequence it would allow propagating exceptions in the normal way until the caller that is prepared to handle them. Ultimately exceptions could propagate even up to `main()`, which is what we'd like to do in our applications: if no other layer before `main()` catches and handles the exception, it propagates to `main()`, `main()` logs the exception and its message as a fatal event to be stored in the system journal and the systemd unit is (typically) configured to restart the application. Restarting the application allows for a chance to recover from potential failures modes that persist (e.g. due to some invalid state stored in RAM) until application restart. Also, terminating the application, in which case the D-Bus daemon returns the standard error `org.freedesktop.DBus.Error.NoReply` to the client, avoids the need to declare an error for internal failures in the D-Bus API. Internal errors in the API specification do not really add value over `org.freedesktop.DBus.Error.NoReply` but only bloat the API as clients can't handle them in any better way than `org.freedesktop.DBus.Error.NoReply`.

The change should be backwards compatible as any code that hasn't propagated unexpected exceptions should still work as before while unexpected exceptions would still propagate through the callstack (excluding the `sd_bus` C functions) but just avoid the resource leaks from the `sd_bus` C functions.

## Other options considered

Resources leaks from the `sd_bus` C functions could of course be avoided by catching all exceptions (or even `catch (...)`) in method implementations. That, however, would require adding some hand-written boilerplate to each and every method implementation. Additionally, as far as we see, there wouldn't be any means to propagate errors to `main()` as (unexpected) exceptions would cause resource leaks and the return value cannot be used to pass error codes.

The GCC option `-fexceptions` isn't really an option either as it still wouldn't automagically deallocate resources from the C code, many times one can't affect the compiler options used to build libsystemd, and -fexceptions is still a compiler specific option.

## Pending actions

The implementation at this point is only a proof-of-concept or demonstration. We are not sure if e.g. `SdBusImpl` is the best / correct place to store the current exception, and secondly, if the change in principle looks good, we should extend the implementation to properties and potentially other necessary places. Also, tests were not modified yet and should be updated accordingly. Finally, the Git history needs to be cleaned up (the first commit dropped and at least a proper commit message written for the second commit).

## Testing

The calculator example was modified to demonstrate the problem (the first commit) and the proposed change (the second commit).

The test can be reproduced with the following commands in the sdbusplus root directory for both commits:
```
rm -rf build/ && meson setup -Dtests=disabled build && cd build && ninja && valgrind --leak-check=full --show-leak-kinds=all ./example/calculator-server
busctl --user call net.poettering.Calculator /net/poettering/calculator net.poettering.Calculator Clear
```

After checking out the first commit, building it and running the calculator server with Valgrind
```
sdbusplus$ rm -rf build/ && meson setup -Dtests=disabled build && cd build && ninja
The Meson build system
Version: 1.0.1
Source dir: /path/to/sdbusplus
Build dir: /path/to/sdbusplus/build
Build type: native build
Project name: sdbusplus
Project version: 1.0.0
C compiler for the host machine: ccache cc (gcc 12.2.1 "cc (GCC) 12.2.1 20221121 (Red Hat 12.2.1-4)")
C linker for the host machine: cc ld.bfd 2.37-37
C++ compiler for the host machine: ccache c++ (gcc 12.2.1 "c++ (GCC) 12.2.1 20221121 (Red Hat 12.2.1-4)")
C++ linker for the host machine: c++ ld.bfd 2.37-37
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: /usr/bin/pkg-config (1.8.0)
Run-time dependency libsystemd found: YES 250
Program python3 (inflection, yaml, mako) found: YES (/path/to/bin/python3) modules: inflection, yaml, mako
Run-time dependency Boost found: YES 1.76.0 (/usr)
Program sdbus++ found: YES (/path/to/sdbusplus/tools/sdbus++)
Program sdbus++ found: YES (overridden)
Program sdbus++-gen-meson found: YES (/path/to/sdbusplus/tools/sdbus++-gen-meson)
Program sdbus++-gen-meson found: YES (overridden)
Header "boost/asio.hpp" has symbol "boost::asio::io_context" : YES
Run-time dependency Boost (found: context, coroutine) found: YES 1.76.0 (/usr)
Build targets in project: 9

sdbusplus 1.0.0

  User defined options
    tests: disabled

Found ninja-1.10.2 at /usr/bin/ninja
[27/27] Linking target example/calculator-server
build$ valgrind --leak-check=full --show-leak-kinds=all ./example/calculator-server
==451108== Memcheck, a memory error detector
==451108== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==451108== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==451108== Command: ./example/calculator-server
==451108==
```
and issuing the call
```
$ busctl --user call net.poettering.Calculator /net/poettering/calculator net.poettering.Calculator Clear
```
the client reports the error
```
Call failed: Remote peer disconnected
```
and the server produces the following results (full Valgrind output omitted):
```
Terminating due to a fatal condition: A propagating exception
==451108==
==451108== HEAP SUMMARY:
==451108==     in use at exit: 3,946 bytes in 32 blocks
==451108==   total heap usage: 142 allocs, 110 frees, 96,623 bytes allocated
==451108==
==451108== 2 bytes in 1 blocks are still reachable in loss record 1 of 27
==451108==    at 0x484586F: malloc (vg_replace_malloc.c:381)
==451108==    by 0x4C6152D: strdup (strdup.c:42)
==451108==    by 0x48C4D7D: bus_node_allocate (bus-objects.c:1503)
==451108==    by 0x48C4EE7: bus_node_allocate (bus-objects.c:1515)
==451108==    by 0x48C4EE7: bus_node_allocate (bus-objects.c:1515)
==451108==    by 0x48C4EE7: bus_node_allocate (bus-objects.c:1515)
==451108==    by 0x48CC0BA: sd_bus_add_object_manager (bus-objects.c:3003)
==451108==    by 0x403A17: sd_bus_add_object_manager (sdbus.hpp:189)
==451108==    by 0x403A17: manager (manager.hpp:49)
==451108==    by 0x403A17: main (calculator-server.cpp:63)
==451108==
[...]
==451108==
==451108== LEAK SUMMARY:
==451108==    definitely lost: 0 bytes in 0 blocks
==451108==    indirectly lost: 0 bytes in 0 blocks
==451108==      possibly lost: 0 bytes in 0 blocks
==451108==    still reachable: 3,946 bytes in 32 blocks
==451108==         suppressed: 0 bytes in 0 blocks
==451108==
==451108== For lists of detected and suppressed errors, rerun with: -s
==451108== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

With the second commit and the same procedure Valgrding reports no leaks (output not redacted)
```
build$ ninja && valgrind --leak-check=full --show-leak-kinds=all ./example/calculator-server
[26/26] Linking target example/calculator-server
==454408== Memcheck, a memory error detector
==454408== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==454408== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==454408== Command: ./example/calculator-server
==454408==
Terminating due to a fatal condition: A propagating exception
==454408==
==454408== HEAP SUMMARY:
==454408==     in use at exit: 0 bytes in 0 blocks
==454408==   total heap usage: 154 allocs, 154 frees, 98,221 bytes allocated
==454408==
==454408== All heap blocks were freed -- no leaks are possible
==454408==
==454408== For lists of detected and suppressed errors, rerun with: -s
==454408== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
and the client still reports the same error (as expected)
```
Call failed: Remote peer disconnected
```

## References

[1] https://lore.kernel.org/openbmc/YTDvfIn4Z05mGdCx@heinlein/
