### PR TITLE
Add an easy way to get the dbus message

### DIFF
--- a/tools/sdbusplus/templates/interface.server.hpp.mako
+++ b/tools/sdbusplus/templates/interface.server.hpp.mako
@@ -119,6 +119,13 @@ ${p.camelCase}(${p.cppTypeParam(interface.name)} value);
             return  _sdbusplus_bus;
         }
 
+    protected:
+        /** @return the current sdbus message, or nullptr if no method is currently being called */
+        sd_bus_message* get_current_message()
+        {
+            return _msg;
+        }
+
     private:
     % for m in interface.methods:
 ${ m.cpp_prototype(loader, interface=interface, ptype='callback-header') }
@@ -141,6 +148,7 @@ ${ m.cpp_prototype(loader, interface=interface, ptype='callback-header') }
         sdbusplus::server::interface_t
                 _${interface.joinedName("_", "interface")};
         bus_t&  _sdbusplus_bus;
+        sd_bus_message* _msg;
 
     % for p in interface.properties:
         ${p.cppTypeParam(interface.name)} _${p.camelCase}${p.default_value(interface.name)};

--- a/tools/sdbusplus/templates/method.prototype.hpp.mako
+++ b/tools/sdbusplus/templates/method.prototype.hpp.mako
@@ -39,7 +39,8 @@ int ${interface.classname}::_callback_${ method.CamelCase }(
 
     try
     {
-        return sdbusplus::sdbuspp::method_callback\
+        o->_msg = msg;
+        auto result = sdbusplus::sdbuspp::method_callback\
     % if len(method.returns) > 1:
 <true>\
     % endif
@@ -52,6 +53,8 @@ int ${interface.classname}::_callback_${ method.CamelCase }(
                                 ${method.parameters_as_list()});
                     }
                 ));
+        o->_msg = nullptr;
+        return result;
     }
     % for e in method.errors:
     catch(const ${interface.errorNamespacedClass(e)}& e)


### PR DESCRIPTION
There doesn't seem to be an easy way to get the dbus message from the dbus methods of the server class. This pull request adds a `get_current_message()` which returns the dbus message.