### PR TITLE
Fix "call to non-constexpr function" compiler error

### DIFF
--- a/include/sdbusplus/bus/match.hpp
+++ b/include/sdbusplus/bus/match.hpp
@@ -142,7 +142,7 @@ constexpr auto interfacesAdded(std::string_view p) noexcept
     return interfacesAdded().append(path(p));
 }
 
-constexpr auto interfacesAddedAtPath(std::string_view p) noexcept
+inline auto interfacesAddedAtPath(std::string_view p) noexcept
 {
     return interfacesAdded().append(argNpath(0, p));
 }
@@ -152,7 +152,7 @@ constexpr auto interfacesRemoved(std::string_view p) noexcept
     return interfacesRemoved().append(path(p));
 }
 
-constexpr auto interfacesRemovedAtPath(std::string_view p) noexcept
+inline auto interfacesRemovedAtPath(std::string_view p) noexcept
 {
     return interfacesRemoved().append(argNpath(0, p));
 }


### PR DESCRIPTION
Change-Id: Ic6c1b5f37641adf61f553dbb5a12b797eaabe221

Without this fix, compiling the sdbusplus-native bitbake recipe would result in the following error:

```
| In file included from ../git/src/bus/match.cpp:3:
| ../git/include/sdbusplus/bus/match.hpp: In function ‘constexpr auto sdbusplus::bus::match::rules::interfacesAddedAtPath(std::string_view)’:
| ../git/include/sdbusplus/bus/match.hpp:148:1: error: call to non-‘constexpr’ function ‘auto sdbusplus::bus::match::rules::argNpath(size_t, std::string_view)’
|   148 | }
|       | ^
```